### PR TITLE
fix printf() type for 32-bit

### DIFF
--- a/dora.c
+++ b/dora.c
@@ -344,7 +344,7 @@ int transact(int sock, bool dosend, struct packet *send, struct packet **recv, i
         uint32_t to = send->server ?: 0xFFFFFFFF;
         if (verbose)
         {
-            warn("Sending %ld-byte packet to %u.%u.%u.%u:\n", DHCP_SIZE + send->optsize, quad(&to));
+            warn("Sending %zu-byte packet to %u.%u.%u.%u:\n", DHCP_SIZE + send->optsize, quad(&to));
             dump((uint8_t *)&send->dhcp, DHCP_SIZE+send->optsize);
             printf("ciaddr=%u.%u.%u.%u yiaddr=%u.%u.%u.%u siaddr=%u.%u.%u.%u\n", quad(&send->dhcp.ciaddr), quad(&send->dhcp.yiaddr), quad(&send->dhcp.siaddr));
         }


### PR DESCRIPTION
DHCP_SIZE is acquired via sizeof(), which returns a size_t, for which
the specifier is %zu (unsigned/size_t)

fixes:
`dora.c:347:18: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'unsigned int' [-Werror=format=]`